### PR TITLE
Don't include nil contribution_page fields in contribution JSON

### DIFF
--- a/lib/blue_state_digital/contribution.rb
+++ b/lib/blue_state_digital/contribution.rb
@@ -33,6 +33,13 @@ module BlueStateDigital
     ]
     attr_accessor *FIELDS
 
+    def as_json(options={})
+      fields_to_exclude = []
+      fields_to_exclude << :contribution_page_id if contribution_page_id.nil?
+      fields_to_exclude << :contribution_page_slug if contribution_page_slug.nil?
+      super(options.merge({except: fields_to_exclude}))
+    end
+
     def save
       begin
         if connection

--- a/spec/blue_state_digital/contribution_spec.rb
+++ b/spec/blue_state_digital/contribution_spec.rb
@@ -24,6 +24,22 @@ describe BlueStateDigital::Contribution do
     :custom_fields
     ) }
 
+  describe 'as_json' do
+    let(:connection) { double }
+
+    it 'should include contribution_page_id and contribution_page_slug if they are set' do
+      contribution = BlueStateDigital::Contribution.new(attributes.merge({ connection: connection, contribution_page_slug: 'donate-here-12', contribution_page_id: 4 }))
+      expect(contribution.as_json).to include('contribution_page_id')
+      expect(contribution.as_json).to include('contribution_page_slug')
+    end
+
+    it 'should not include contribution_page_id and contribution_page_slug if they are not set' do
+      contribution = BlueStateDigital::Contribution.new(attributes.merge({ connection: connection }))
+      expect(contribution.as_json).not_to include('contribution_page_id')
+      expect(contribution.as_json).not_to include('contribution_page_slug')
+    end
+  end
+
   describe 'save' do
     let(:connection) { double }
     let(:contribution) { BlueStateDigital::Contribution.new(attributes.merge({ connection: connection })) }


### PR DESCRIPTION
If these fields are included and nil, the add_external_contribution API does not work properly (according to advise from BSD Support)
