### PR TITLE
Basic support for signup forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ unsub.unsubscribe! # raises on error, returns true on success.
 connection = BlueStateDigital::Connection.new(host:'foo.com' api_id: 'bar', api_secret: 'magic_secret')
 signup_form = BlueStateDigital::SignupForm.clone(clone_from_id: 3, slug: 'foo', name: 'my new form', public_title: 'Sign Here For Puppies', connection: connection)
 
-# The keys of this hash should match the labels of the signup form's fields
-signup_form.process_signup({'first_name' => 'George', 'last_name' => 'Washington', 'email_address' => 'george@example.com', 'a_custom_field' => 'some custom data', 'email_opt_in' => true})
+# The keys of the field_data hash should match the labels of the signup form's fields
+signup_form.process_signup({field_data: {'First Name' => 'George', 'Last Name' => 'Washington', 'Email Address' => 'george@example.com', 'A Custom Field' => 'some custom data'},
+                            email_opt_in: true, source: 'foo', subsource: 'bar'})
 ```
 
 ### Dataset integration 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ unsub.unsubscribe! # raises on error, returns true on success.
 ```ruby
 connection = BlueStateDigital::Connection.new(host:'foo.com' api_id: 'bar', api_secret: 'magic_secret')
 signup_form = BlueStateDigital::SignupForm.clone(clone_from_id: 3, slug: 'foo', name: 'my new form', public_title: 'Sign Here For Puppies', connection: connection)
+signup_form.set_cons_group(2345)
 
 # The keys of the field_data hash should match the labels of the signup form's fields
 signup_form.process_signup({field_data: {'First Name' => 'George', 'Last Name' => 'Washington', 'Email Address' => 'george@example.com', 'A Custom Field' => 'some custom data'},

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ unsub = BlueStateDigital::EmailUnsubscribe.new({email: 'george@washington.com', 
 unsub.unsubscribe! # raises on error, returns true on success.
 ```
 
+### Signup Forms
+
+```ruby
+connection = BlueStateDigital::Connection.new(host:'foo.com' api_id: 'bar', api_secret: 'magic_secret')
+signup_form = BlueStateDigital::SignupForm.clone(clone_from_id: 3, slug: 'foo', name: 'my new form', public_title: 'Sign Here For Puppies', connection: connection)
+
+# The keys of this hash should match the labels of the signup form's fields
+signup_form.process_signup({'first_name' => 'George', 'last_name' => 'Washington', 'email_address' => 'george@example.com', 'a_custom_field' => 'some custom data', 'email_opt_in' => true})
+```
+
 ### Dataset integration 
 
 [BSD API for uploading Dataset](https://cshift.cp.bsd.net/page/api/doc#---------------------upload_dataset-----------------)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ signup_form = BlueStateDigital::SignupForm.clone(clone_from_id: 3, slug: 'foo', 
 signup_form.set_cons_group(2345)
 
 # The keys of the field_data hash should match the labels of the signup form's fields
-signup_form.process_signup({field_data: {'First Name' => 'George', 'Last Name' => 'Washington', 'Email Address' => 'george@example.com', 'A Custom Field' => 'some custom data'},
-                            email_opt_in: true, source: 'foo', subsource: 'bar'})
+signup_form.process_signup(field_data: {'First Name' => 'George', 'Last Name' => 'Washington', 'Email Address' => 'george@example.com', 'A Custom Field' => 'some custom data'},
+                           email_opt_in: true, source: 'foo', subsource: 'bar')
 ```
 
 ### Dataset integration 

--- a/lib/blue_state_digital.rb
+++ b/lib/blue_state_digital.rb
@@ -25,6 +25,7 @@ require "blue_state_digital/dataset"
 require "blue_state_digital/dataset_map"
 require "blue_state_digital/error_middleware"
 require "blue_state_digital/email_unsubscribe"
+require "blue_state_digital/signup_form"
 
 
 I18n.enforce_available_locales = false

--- a/lib/blue_state_digital/constituent.rb
+++ b/lib/blue_state_digital/constituent.rb
@@ -95,10 +95,10 @@ module BlueStateDigital
   end
 
   class Constituents < CollectionResource
-    # TODO: write a simple email->id func that doesn't use deferred results
-
     def get_constituents_by_email email, bundles= [ 'cons_group' ]
-      get_constituents "email=#{email}", bundles
+      result = connection.perform_request('/cons/get_constituents_by_email', filter_parameters({emails: email, :bundles=> bundles.join(',')}), "GET")
+
+      from_response(result)
     end
 
     def get_constituents_by_id(cons_ids, bundles = ['cons_group'])

--- a/lib/blue_state_digital/constituent.rb
+++ b/lib/blue_state_digital/constituent.rb
@@ -95,6 +95,8 @@ module BlueStateDigital
   end
 
   class Constituents < CollectionResource
+    # TODO: write a simple email->id func that doesn't use deferred results
+
     def get_constituents_by_email email, bundles= [ 'cons_group' ]
       get_constituents "email=#{email}", bundles
     end

--- a/lib/blue_state_digital/error_middleware.rb
+++ b/lib/blue_state_digital/error_middleware.rb
@@ -2,6 +2,7 @@ module BlueStateDigital
   class Unauthorized < ::Faraday::Error::ClientError ; end
   class ResourceDoesNotExist < ::Faraday::Error::ClientError ; end
   class EmailNotFound < ::Faraday::Error::ClientError ; end
+  class XmlErrorResponse < ::Faraday::Error::ClientError ; end
 
   class ErrorMiddleware < ::Faraday::Response::RaiseError
     def on_complete(env)
@@ -11,7 +12,9 @@ module BlueStateDigital
       when 403
         raise BlueStateDigital::Unauthorized, response_values(env).to_s
       when 409
-        if env.body =~ /does not exist/
+        if env.body =~ /<error>/
+          raise BlueStateDigital::XmlErrorResponse, env.body
+        elsif env.body =~ /does not exist/
           raise BlueStateDigital::ResourceDoesNotExist, response_values(env).to_s
         elsif env.body =~ /Email not found/
           raise BlueStateDigital::EmailNotFound, response_values(env).to_s

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -28,7 +28,7 @@ module BlueStateDigital
       connection = options[:connection]
 
       params = {signup_form_id: clone_from_id, title: public_title, signup_form_name: name, slug: slug}
-      xml_response = connection.perform_request '/signup/clone_form', params, 'POST', nil
+      xml_response = connection.perform_request '/signup/clone_form', {}, 'POST', params
 
       doc = Nokogiri::XML(xml_response)
       record = doc.xpath('//signup_form').first

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -36,7 +36,7 @@ module BlueStateDigital
         id = record.xpath('id').text.to_i
         SignupForm.new(id: id, name: name, slug: slug, public_title: public_title, connection: connection)
       else
-        raise "Set constituent data failed with message: #{xml_response}"
+        raise "Cloning signup form failed with message: #{xml_response}"
       end
     end
 

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -78,6 +78,10 @@ module BlueStateDigital
       end
     end
 
+    def set_cons_group(cons_group_id)
+      connection.perform_request('/signup/set_cons_group', {signup_form_id: self.id}, 'POST', {cons_group_id: cons_group_id})
+    end
+
     private
 
     def form_fields

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -53,7 +53,7 @@ module BlueStateDigital
           end
           form.email_opt_in(data[:email_opt_in] ? '1' : '0')
           form.source(data[:source]) if data.has_key?(:source)
-          form.source(data[:subsource]) if data.has_key?(:subsource)
+          form.subsource(data[:subsource]) if data.has_key?(:subsource)
         end
       end
 

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -1,20 +1,20 @@
 module BlueStateDigital
   class SignupForm < ApiDataModel
-    FIELDS = [:id, :clone_from_id, :signup_form_name, :signup_form_slug, :form_public_title, :create_dt]
+    FIELDS = [:id, :name, :slug, :public_title, :create_dt]
     attr_accessor *FIELDS
 
-    def save
-      params = {signup_form_id: clone_from_id, title: form_public_title,
-                signup_form_name: signup_form_name, slug: signup_form_slug}
+    def self.clone(clone_from_id, slug, name, public_title, connection)
+      params = {signup_form_id: clone_from_id, title: public_title, signup_form_name: name, slug: slug}
       xml_response = connection.perform_request '/signup/clone_form', params, 'POST', nil
+
       doc = Nokogiri::XML(xml_response)
       record = doc.xpath('//signup_form').first
       if record
-        self.id = record.xpath('id').text.to_i
+        id = record.xpath('id').text.to_i
+        SignupForm.new(id: id, name: name, slug: slug, public_title: public_title, connection: connection)
       else
         raise "Set constituent data failed with message: #{xml_response}"
       end
-      self
     end
   end
 end

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -40,11 +40,28 @@ module BlueStateDigital
       end
     end
 
+    # Takes a hash of {'field label' => 'field value'}
     def process_signup(data)
-      # TODO:
-      # construct XML with the data
-      # call process_signup endpoint
-      # return success or errors
+      # Construct the XML to send
+      builder = Builder::XmlMarkup.new
+      builder.instruct! :xml, version: '1.0', encoding: 'utf-8'
+      xml_body = builder.api do |api|
+        api.signup_form(id: self.id) do |form|
+          form_fields.each do |field|
+            form.signup_form_field(data[field.label], id: field.id)
+          end
+          form.email_opt_in(data['email_opt_in'])
+          # TODO: source, subsource?
+        end
+      end
+
+      # Post it to the endpoint
+      response = connection.perform_request_raw '/signup/process_signup', params, 'POST', nil
+      if response.status >= 200 && response.status < 300
+        return true
+      else
+        raise "process signup failed with message: #{response.body}"
+      end
     end
 
     private

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -52,11 +52,8 @@ module BlueStateDigital
             form.signup_form_field(field_data[field.label], id: field.id)
           end
           form.email_opt_in(data[:email_opt_in] ? '1' : '0')
-          [:source, :subsource].each do |key|
-            if data.has_key?(key)
-              form.source(data[key])
-            end
-          end
+          form.source(data[:source]) if data.has_key?(:source)
+          form.source(data[:subsource]) if data.has_key?(:subsource)
         end
       end
 

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -1,0 +1,20 @@
+module BlueStateDigital
+  class SignupForm < ApiDataModel
+    FIELDS = [:id, :clone_from_id, :signup_form_name, :signup_form_slug, :form_public_title, :create_dt]
+    attr_accessor *FIELDS
+
+    def save
+      params = {signup_form_id: clone_from_id, title: form_public_title,
+                signup_form_name: signup_form_name, slug: signup_form_slug}
+      xml_response = connection.perform_request '/signup/clone_form', params, 'POST', nil
+      doc = Nokogiri::XML(xml_response)
+      record = doc.xpath('//signup_form').first
+      if record
+        self.id = record.xpath('id').text.to_i
+      else
+        raise "Set constituent data failed with message: #{xml_response}"
+      end
+      self
+    end
+  end
+end

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -50,13 +50,13 @@ module BlueStateDigital
           form_fields.each do |field|
             form.signup_form_field(data[field.label], id: field.id)
           end
-          form.email_opt_in(data['email_opt_in'])
+          form.email_opt_in(data['email_opt_in'] ? '1' : '0')
           # TODO: source, subsource?
         end
       end
 
       # Post it to the endpoint
-      response = connection.perform_request_raw '/signup/process_signup', params, 'POST', nil
+      response = connection.perform_request_raw '/signup/process_signup', {}, 'POST', xml_body
       if response.status >= 200 && response.status < 300
         return true
       else

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -40,18 +40,23 @@ module BlueStateDigital
       end
     end
 
-    # Takes a hash of {'field label' => 'field value'}
+    # Takes a hash like {field_data: {'field label' => 'field value'}, email_opt_in: false, source: 'foo', subsource: 'bar'}
     def process_signup(data)
       # Construct the XML to send
+      field_data = data[:field_data]
       builder = Builder::XmlMarkup.new
       builder.instruct! :xml, version: '1.0', encoding: 'utf-8'
       xml_body = builder.api do |api|
         api.signup_form(id: self.id) do |form|
           form_fields.each do |field|
-            form.signup_form_field(data[field.label], id: field.id)
+            form.signup_form_field(field_data[field.label], id: field.id)
           end
-          form.email_opt_in(data['email_opt_in'] ? '1' : '0')
-          # TODO: source, subsource?
+          form.email_opt_in(data[:email_opt_in] ? '1' : '0')
+          [:source, :subsource].each do |key|
+            if data.has_key?(key)
+              form.source(data[key])
+            end
+          end
         end
       end
 

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -3,7 +3,13 @@ module BlueStateDigital
     FIELDS = [:id, :name, :slug, :public_title, :create_dt]
     attr_accessor *FIELDS
 
-    def self.clone(clone_from_id, slug, name, public_title, connection)
+    def self.clone(options)
+      clone_from_id = options[:clone_from_id]
+      slug = options[:slug]
+      name = options[:name]
+      public_title = options[:public_title]
+      connection = options[:connection]
+
       params = {signup_form_id: clone_from_id, title: public_title, signup_form_name: name, slug: slug}
       xml_response = connection.perform_request '/signup/clone_form', params, 'POST', nil
 

--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -2,6 +2,7 @@ module BlueStateDigital
   class SignupForm < ApiDataModel
     FIELDS = [:id, :name, :slug, :public_title, :create_dt]
     attr_accessor *FIELDS
+    attr_accessor :form_fields
 
     def self.clone(options)
       clone_from_id = options[:clone_from_id]
@@ -22,5 +23,20 @@ module BlueStateDigital
         raise "Set constituent data failed with message: #{xml_response}"
       end
     end
+
+    def process_signup(data)
+      # TODO: fetch form fields if they don't exist yet
+      # construct XML with the data
+      # call process_signup endpoint
+      # return success or errors
+    end
+
+    private
+
+    def fetch_form_fields
+      # TODO: call list_form_fields and set form_fields with what comes back
+    end
   end
+
+  # TODO: SignupFormField class
 end

--- a/spec/blue_state_digital/constituent_spec.rb
+++ b/spec/blue_state_digital/constituent_spec.rb
@@ -254,8 +254,7 @@ describe BlueStateDigital::Constituent do
 
     describe ".get_constituents_by_email" do
       it "should make a filtered constituents query" do
-        expect(connection).to receive(:perform_request).with('/cons/get_constituents', {:filter=>"email=george@washington.com", :bundles => 'cons_group'}, "GET").and_return("deferred_id")
-        expect(connection).to receive(:perform_request).with('/get_deferred_results', {deferred_id: "deferred_id"}, "GET").and_return(@single_constituent)
+        expect(connection).to receive(:perform_request).with('/cons/get_constituents_by_email', {:emails=>"george@washington.com", :bundles => 'cons_group'}, "GET").and_return(@single_constituent)
         response = connection.constituents.get_constituents_by_email("george@washington.com").first
         expect(response.id).to eq("4382")
         expect(response.firstname).to eq('Bob')
@@ -263,8 +262,7 @@ describe BlueStateDigital::Constituent do
 
       it "should return constituents' details based on bundles" do
         bundles = 'cons_addr'
-        expect(connection).to receive(:perform_request).with('/cons/get_constituents', {:filter=>"email=george@washington.com", :bundles => bundles}, "GET").and_return("deferred_id")
-        expect(connection).to receive(:perform_request).with('/get_deferred_results', {deferred_id: "deferred_id"}, "GET").and_return(@constituent_with_addr)
+        expect(connection).to receive(:perform_request).with('/cons/get_constituents_by_email', {:emails=>"george@washington.com", :bundles => bundles}, "GET").and_return(@constituent_with_addr)
         response = connection.constituents.get_constituents_by_email("george@washington.com", ['cons_addr']).first
         response.addresses[0].addr1 == "aaa1"
         response.addresses[0].addr2 == "aaa2"

--- a/spec/blue_state_digital/signup_form_spec.rb
+++ b/spec/blue_state_digital/signup_form_spec.rb
@@ -20,7 +20,8 @@ describe BlueStateDigital::SignupForm do
                                                             slug: 'foo'},
                                                            'POST', nil).and_return(response)
 
-      form = BlueStateDigital::SignupForm.clone(1, 'foo', 'Signup Form Foo', 'Sign Up Here', connection)
+      form = BlueStateDigital::SignupForm.clone(clone_from_id: 1, slug: 'foo', name: 'Signup Form Foo',
+                                                public_title: 'Sign Up Here', connection: connection)
       expect(form.id).to eq(3)
       expect(form.name).to eq('Signup Form Foo')
       expect(form.slug).to eq('foo')

--- a/spec/blue_state_digital/signup_form_spec.rb
+++ b/spec/blue_state_digital/signup_form_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe BlueStateDigital::SignupForm do
   let(:connection) { BlueStateDigital::Connection.new({}) }
 
-  describe '#save' do
-    it 'should clone a form with the specified attributes' do
+  describe '.clone' do
+    it 'should create a new SignupForm' do
       response = <<-EOF
         <?xml version="1.0" encoding="utf-8"?>
         <api>
@@ -13,7 +13,6 @@ describe BlueStateDigital::SignupForm do
           </signup_form>
         </api>
       EOF
-
       expect(connection).to receive(:perform_request).with('/signup/clone_form',
                                                            {signup_form_id: 1,
                                                             title: 'Sign Up Here',
@@ -21,11 +20,11 @@ describe BlueStateDigital::SignupForm do
                                                             slug: 'foo'},
                                                            'POST', nil).and_return(response)
 
-      form = BlueStateDigital::SignupForm.new(clone_from_id: 1, signup_form_name: 'Signup Form Foo',
-                                              signup_form_slug: 'foo', form_public_title: 'Sign Up Here',
-                                              connection: connection)
-      form.save
+      form = BlueStateDigital::SignupForm.clone(1, 'foo', 'Signup Form Foo', 'Sign Up Here', connection)
       expect(form.id).to eq(3)
+      expect(form.name).to eq('Signup Form Foo')
+      expect(form.slug).to eq('foo')
+      expect(form.public_title).to eq('Sign Up Here')
     end
   end
 end

--- a/spec/blue_state_digital/signup_form_spec.rb
+++ b/spec/blue_state_digital/signup_form_spec.rb
@@ -86,7 +86,7 @@ describe BlueStateDigital::SignupForm do
       expect(connection).to receive(:perform_request_raw).with('/signup/process_signup', {}, 'POST', expected_body).and_return(double(body: '', status: 200))
 
       signup_data = {'First Name' => 'Susan', 'Middle Initial' => 'B', 'Last Name' => 'Anthony'}
-      signup_form.process_signup({field_data: signup_data, email_opt_in: true, source: 'foo'})
+      signup_form.process_signup(field_data: signup_data, email_opt_in: true, source: 'foo')
     end
   end
 

--- a/spec/blue_state_digital/signup_form_spec.rb
+++ b/spec/blue_state_digital/signup_form_spec.rb
@@ -13,12 +13,11 @@ describe BlueStateDigital::SignupForm do
           </signup_form>
         </api>
       EOF
-      expect(connection).to receive(:perform_request).with('/signup/clone_form',
+      expect(connection).to receive(:perform_request).with('/signup/clone_form', {}, 'POST',
                                                            {signup_form_id: 1,
                                                             title: 'Sign Up Here',
                                                             signup_form_name: 'Signup Form Foo',
-                                                            slug: 'foo'},
-                                                           'POST', nil).and_return(response)
+                                                            slug: 'foo'}).and_return(response)
 
       form = BlueStateDigital::SignupForm.clone(clone_from_id: 1, slug: 'foo', name: 'Signup Form Foo',
                                                 public_title: 'Sign Up Here', connection: connection)

--- a/spec/blue_state_digital/signup_form_spec.rb
+++ b/spec/blue_state_digital/signup_form_spec.rb
@@ -71,8 +71,6 @@ describe BlueStateDigital::SignupForm do
     end
 
     it 'should call process_signup' do
-      signup_data = {'First Name' => 'Susan', 'Middle Initial' => 'B', 'Last Name' => 'Anthony', 'email_opt_in' => true}
-
       expected_body_readable = <<-EOF
         <?xml version="1.0" encoding="utf-8"?>
         <api>
@@ -80,6 +78,7 @@ describe BlueStateDigital::SignupForm do
             <signup_form_field id="83">Susan</signup_form_field>
             <signup_form_field id="84">Anthony</signup_form_field>
             <email_opt_in>1</email_opt_in>
+            <source>foo</source>
           </signup_form>
         </api>
       EOF
@@ -87,7 +86,8 @@ describe BlueStateDigital::SignupForm do
 
       expect(connection).to receive(:perform_request_raw).with('/signup/process_signup', {}, 'POST', expected_body).and_return(double(body: '', status: 200))
 
-      signup_form.process_signup(signup_data)
+      signup_data = {'First Name' => 'Susan', 'Middle Initial' => 'B', 'Last Name' => 'Anthony'}
+      signup_form.process_signup({field_data: signup_data, email_opt_in: true, source: 'foo'})
     end
   end
 end

--- a/spec/blue_state_digital/signup_form_spec.rb
+++ b/spec/blue_state_digital/signup_form_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe BlueStateDigital::SignupForm do
+  let(:connection) { BlueStateDigital::Connection.new({}) }
+
+  describe '#save' do
+    it 'should clone a form with the specified attributes' do
+      response = <<-EOF
+        <?xml version="1.0" encoding="utf-8"?>
+        <api>
+          <signup_form>
+            <id>3</id>
+          </signup_form>
+        </api>
+      EOF
+
+      expect(connection).to receive(:perform_request).with('/signup/clone_form',
+                                                           {signup_form_id: 1,
+                                                            title: 'Sign Up Here',
+                                                            signup_form_name: 'Signup Form Foo',
+                                                            slug: 'foo'},
+                                                           'POST', nil).and_return(response)
+
+      form = BlueStateDigital::SignupForm.new(clone_from_id: 1, signup_form_name: 'Signup Form Foo',
+                                              signup_form_slug: 'foo', form_public_title: 'Sign Up Here',
+                                              connection: connection)
+      form.save
+      expect(form.id).to eq(3)
+    end
+  end
+end

--- a/spec/blue_state_digital/signup_form_spec.rb
+++ b/spec/blue_state_digital/signup_form_spec.rb
@@ -89,4 +89,15 @@ describe BlueStateDigital::SignupForm do
       signup_form.process_signup({field_data: signup_data, email_opt_in: true, source: 'foo'})
     end
   end
+
+  describe '#set_cons_group' do
+    let(:signup_form) { BlueStateDigital::SignupForm.new(id: 3, name: 'A Form', slug: 'asdf', public_title: 'The Best Form', connection: connection) }
+    let(:cons_group_id) { 123 }
+
+    it 'should call set_cons_group' do
+      expect(connection).to receive(:perform_request).with('/signup/set_cons_group', {signup_form_id: signup_form.id}, 'POST', {cons_group_id: cons_group_id}).and_return('')
+
+      signup_form.set_cons_group(cons_group_id)
+    end
+  end
 end


### PR DESCRIPTION
This adds support for Signup Forms.
* Cloning a signup form
* Setting the constituent group associated with the form
* Processing a signup (mapping a hash of data to form fields)

It also changes the get_constituents_by_email method to use the get_constituents_by_email endpoint instead of the slower and less synchronous get_constituents.