### PR TITLE
Support for form-defined email opt-ins

### DIFF
--- a/lib/blue_state_digital/signup_form.rb
+++ b/lib/blue_state_digital/signup_form.rb
@@ -44,7 +44,9 @@ module BlueStateDigital
           form_fields.each do |field|
             form.signup_form_field(field_data[field.label], id: field.id)
           end
-          form.email_opt_in(email_opt_in ? '1' : '0')
+          unless email_opt_in.nil?
+            form.email_opt_in(email_opt_in ? '1' : '0')            
+          end
           form.source(source) unless source.nil?
           form.subsource(subsource) unless subsource.nil?
         end


### PR DESCRIPTION
BSD doesn't allow the email opt-in to be defined unless the form is set to `User opt-in`. With this change you can pass nil to not set email_opt_in on the form object
