### PR TITLE
Deprecate set_constituent_data in favor of upsert_constituent_data

### DIFF
--- a/lib/blue_state_digital/constituent.rb
+++ b/lib/blue_state_digital/constituent.rb
@@ -11,7 +11,7 @@ module BlueStateDigital
     end
 
     def save
-      xml = connection.perform_request '/cons/set_constituent_data', {}, "POST", self.to_xml
+      xml = connection.wait_for_deferred_result(  connection.perform_request '/cons/upsert_constituent_data', {}, "POST", self.to_xml )
       doc = Nokogiri::XML(xml)
       record =  doc.xpath('//cons').first
       if record

--- a/spec/blue_state_digital/constituent_spec.rb
+++ b/spec/blue_state_digital/constituent_spec.rb
@@ -395,7 +395,7 @@ describe BlueStateDigital::Constituent do
     output << "</cons>"
     output << "</api>"
 
-    expect(connection).to receive(:perform_request).with('/cons/set_constituent_data', {}, "POST", input) { output }
+    expect(connection).to receive(:perform_request).with('/cons/upsert_constituent_data', {}, "POST", input) { output }
 
     cons_data = BlueStateDigital::Constituent.new(data)
     cons_data.save


### PR DESCRIPTION
Hey there. I just made these modifications on the vendored version of this plugin we use on our project, perhaps they will save other users some time. Per the notification email sent out today:

> Effective December 14, 2018, one API method -- /set_constituent_data -- will be deprecated and replaced by a new method providing a more stable experience for both API and conventional users. Documentation for this new method is now available at the link below.
>
> Documentation: /upsert_constituent_data
>
> The new /upsert_constituent_data returns deferred results in all cases, unlike the deprecated /set_constituent_data method.
>
>Prior to December 14, 2018, your organization will need to modify all existing integrations between your applications and the BSD Tools that rely on the deprecated /set_constituent_data method, to instead use the new /upsert_constituent_data method.